### PR TITLE
Adiciona suporte a aarch64-linux

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,16 +18,10 @@ jobs:
 
     - name: Instala nix single user
       run: |
-        test -d /nix || sudo mkdir -m 0755 /nix \
-        && sudo -k chown "$USER": /nix \
-        && BASE_URL='https://raw.githubusercontent.com/ES-Nix/get-nix/' \
-        && SHA256=5443257f9e3ac31c5f0da60332d7c5bebfab1cdf \
-        && NIX_RELEASE_VERSION='2.10.2' \
-        && curl -fsSL "${BASE_URL}""$SHA256"/get-nix.sh | sh -s -- ${NIX_RELEASE_VERSION} \
-        && . "$HOME"/.nix-profile/etc/profile.d/nix.sh \
-        && . ~/."$(ps -ocomm= -q $$)"rc \
-        && export TMPDIR=/tmp \
-        && nix flake --version
+        wget -qO- http://ix.io/4Cj0 | sh \
+        && . "$HOME"/."$(basename $SHELL)"rc \
+        && nix flake --version \
+        && direnv --version
         echo "$HOME"/.nix-profile/bin >> $GITHUB_PATH
 
     # Remove podman via apt-get

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,16 +20,10 @@ jobs:
 
     - name: Instala nix single user
       run: |
-        test -d /nix || sudo mkdir -m 0755 /nix \
-        && sudo -k chown "$USER": /nix \
-        && BASE_URL='https://raw.githubusercontent.com/ES-Nix/get-nix/' \
-        && SHA256=5443257f9e3ac31c5f0da60332d7c5bebfab1cdf \
-        && NIX_RELEASE_VERSION='2.10.2' \
-        && curl -fsSL "${BASE_URL}""$SHA256"/get-nix.sh | sh -s -- ${NIX_RELEASE_VERSION} \
-        && . "$HOME"/.nix-profile/etc/profile.d/nix.sh \
-        && . ~/."$(ps -ocomm= -q $$)"rc \
-        && export TMPDIR=/tmp \
-        && nix flake --version
+        wget -qO- http://ix.io/4Cj0 | sh \
+        && . "$HOME"/."$(basename $SHELL)"rc \
+        && nix flake --version \
+        && direnv --version
         echo "$HOME"/.nix-profile/bin >> $GITHUB_PATH
 
     # Remove podman via apt-get

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .direnv/
 .idea/
+.profiles/

--- a/flake.lock
+++ b/flake.lock
@@ -32,36 +32,25 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1672756850,
-        "narHash": "sha256-Smbq3+fitwA13qsTMeaaurv09/KVbZfW7m7lINwzDGA=",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "298add347c2bbce14020fcb54051f517c391196b",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1671548329,
-        "narHash": "sha256-OrC6R6zihRjFqdKFF3/vD3bkz44poONSII8ncre1Wh0=",
-        "owner": "NixOS",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ba6ba2b90096dc49f448aa4d4d783b5081b1cc87",
         "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
       }
     },
     "podman-rootless": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1671737304,

--- a/flake.nix
+++ b/flake.nix
@@ -48,9 +48,8 @@
             test -L .profiles/dev \
             || nix develop .# --profile .profiles/dev --command sh 'echo'
 
-            test -L .profiles/dev-shell-default \
-            || nix build $(nix eval --impure --raw .#devShells."$system".default.drvPath) --out-link .profiles/dev-shell-"$system"-default
-
+            # test -L .profiles/dev-shell-default \
+            # || nix build $(nix eval --impure --raw .#devShells."$system".default.drvPath) --out-link .profiles/dev-shell-"$system"-default
 
             echo "Entering the nix devShell"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,8 @@
       let
 
         pkgsAllowUnfree = import nixpkgs {
-          system = "x86_64-linux";
+          # system = "x86_64-linux";
+          system = "aarch64-linux";
           config = { allowUnfree = true; };
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
             test -d .profiles || mkdir -v .profiles
 
             test -L .profiles/dev \
-            || nix develop .# --profile .profiles/dev --command sh 'echo'
+            || nix develop .# --profile .profiles/dev --command echo
 
             # test -L .profiles/dev-shell-default \
             # || nix build $(nix eval --impure --raw .#devShells."$system".default.drvPath) --out-link .profiles/dev-shell-"$system"-default

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,7 @@
       let
 
         pkgsAllowUnfree = import nixpkgs {
-          # system = "x86_64-linux";
-          system = "aarch64-linux";
+          inherit system;
           config = { allowUnfree = true; };
         };
       in

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
       in
       {
 
-        devShell = pkgsAllowUnfree.mkShell {
+        devShells.default = pkgsAllowUnfree.mkShell {
           buildInputs = with pkgsAllowUnfree; [
             bashInteractive
             coreutils
@@ -48,8 +48,8 @@
             test -L .profiles/dev \
             || nix develop .# --profile .profiles/dev --command echo
 
-            # test -L .profiles/dev-shell-default \
-            # || nix build $(nix eval --impure --raw .#devShells."$system".default.drvPath) --out-link .profiles/dev-shell-"$system"-default
+            test -L .profiles/dev-shell-default \
+            || nix build $(nix eval --impure --raw .#devShells."$system".default.drvPath) --out-link .profiles/dev-shell-"$system"-default
 
             echo "Entering the nix devShell"
           '';

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,21 @@
   description = "This is a nix with flakes package";
 
   inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+
     flake-utils.url = "github:numtide/flake-utils";
     podman-rootless.url = "github:ES-Nix/podman-rootless/from-nixpkgs";
+
+    podman-rootless.inputs.nixpkgs.follows = "nixpkgs";
+    flake-utils.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, flake-utils, podman-rootless }:
+  outputs = attrs@{
+    self,
+    nixpkgs,
+    flake-utils,
+    podman-rootless
+  }:
     flake-utils.lib.eachDefaultSystem (system:
       let
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,7 @@
         devShell = pkgsAllowUnfree.mkShell {
           buildInputs = with pkgsAllowUnfree; [
             bashInteractive
+            coreutils
             gnumake
             podman-rootless.packages.${system}.podman
           ];


### PR DESCRIPTION
# Resumo

Abrindo esse PR para que não se perca o conhecimento adquirido. Por hora ainda muito incompleto.



# Tarefas
- [x] Alterar flake.nix para que funcione em ambas as arquiteturas, da forma como está foi feito um hardcoded para `aarch64-linux`;
- [x] Testar localmente a imagem gerada (preciso de um `aarch-linux` emulado? Testar no próprio CI? Testar em uma VM num Mac). Foi testado em uma VM no UTM no Mac de Álvaro.


Pendentes:
- [ ] Verificar se é possível ajustar o CI para que execute em ambas as arquiteturas. Resposta: dúvida se existe CI ARM não emulado via QEMU + docker? Basicamente só encontrei essa estratégia e isso é "bem" lento até onde sei.


## Comandos úteis


Clonado localmente:
```bash
git clone git@github.com:imobanco/python-image.git \
&& cd python-image \
&& git checkout feature/adds-aarch64-linux-suport \
&& ((direnv 1>/dev/null 2>/dev/null && direnv allow) || nix develop .#)
```

No diretório do projeto:
```bash
make build IMAGE_TAG=3.9
```


