### PR TITLE
Remove: follows do flake-utils e urls do ix.io, e adiciona nix fmt

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,9 +18,17 @@ jobs:
 
     - name: Instala nix single user
       run: |
-        wget -qO- http://ix.io/4Cj0 | sh \
-        && . "$HOME"/."$(basename $SHELL)"rc \
+        BASE_URL='https://raw.githubusercontent.com/ES-Nix/get-nix/' \
+        && SHA256=87fa0f1dbfdd28a1f99b39d5bd4dcc39de97bc64 \
+        && NIX_RELEASE_VERSION='2.10.2' \
+        && curl -fsSL "${BASE_URL}""$SHA256"/get-nix.sh | sh -s -- ${NIX_RELEASE_VERSION} \
+        && . "$HOME"/.nix-profile/etc/profile.d/nix.sh \
+        && . ~/."$(basename $SHELL)"rc \
+        && export TMPDIR=/tmp \
         && nix flake --version \
+        && nix registry pin nixpkgs github:NixOS/nixpkgs/ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b \
+        && curl -fsSL https://raw.githubusercontent.com/ES-Nix/get-nix/"$SHA256"/install_direnv_and_nix_direnv.sh | sh \
+        && . ~/."$(basename $SHELL)"rc \
         && direnv --version
         echo "$HOME"/.nix-profile/bin >> $GITHUB_PATH
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,17 @@ jobs:
 
     - name: Instala nix single user
       run: |
-        wget -qO- http://ix.io/4Cj0 | sh \
-        && . "$HOME"/."$(basename $SHELL)"rc \
+        BASE_URL='https://raw.githubusercontent.com/ES-Nix/get-nix/' \
+        && SHA256=87fa0f1dbfdd28a1f99b39d5bd4dcc39de97bc64 \
+        && NIX_RELEASE_VERSION='2.10.2' \
+        && curl -fsSL "${BASE_URL}""$SHA256"/get-nix.sh | sh -s -- ${NIX_RELEASE_VERSION} \
+        && . "$HOME"/.nix-profile/etc/profile.d/nix.sh \
+        && . ~/."$(basename $SHELL)"rc \
+        && export TMPDIR=/tmp \
         && nix flake --version \
+        && nix registry pin nixpkgs github:NixOS/nixpkgs/ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b \
+        && curl -fsSL https://raw.githubusercontent.com/ES-Nix/get-nix/"$SHA256"/install_direnv_and_nix_direnv.sh | sh \
+        && . ~/."$(basename $SHELL)"rc \
         && direnv --version
         echo "$HOME"/.nix-profile/bin >> $GITHUB_PATH
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
     podman-rootless.url = "github:ES-Nix/podman-rootless/from-nixpkgs";
 
     podman-rootless.inputs.nixpkgs.follows = "nixpkgs";
-    flake-utils.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs = attrs@{
@@ -30,6 +29,9 @@
           (builtins.concatStringsSep " " (builtins.attrValues attrs));
       in
       {
+
+        # nix fmt
+        formatter = pkgsAllowUnfree.nixpkgs-fmt;
 
         devShells.default = pkgsAllowUnfree.mkShell {
           buildInputs = with pkgsAllowUnfree; [


### PR DESCRIPTION
## Resumo

Como o título descreve, remove a warning:
`warning: input 'flake-utils' has an override for a non-existent input 'nixpkgs'`
e adicona o atributo formatter que possibilita `nix fmt`.